### PR TITLE
fix: do not list gitpad in the buflist

### DIFF
--- a/lua/gitpad/init.lua
+++ b/lua/gitpad/init.lua
@@ -147,12 +147,10 @@ function M.open_window(opts)
     win_opts.title_pos = 'left'
   end
 
-  local bufnr = vim.api.nvim_create_buf(false, true)
+  local bufnr = vim.fn.bufadd(path)
   if gitpad_win_id == nil then
     gitpad_win_id = vim.api.nvim_open_win(bufnr, true, win_opts)
   end
-
-  vim.cmd.edit(path)
 
   vim.api.nvim_set_option_value('filetype', 'markdown', { buf = bufnr })
   vim.api.nvim_set_option_value('buflisted', false, { buf = bufnr })


### PR DESCRIPTION
It seems that `vim.cmd.edit` creates a new buffer and it causes it to get displayed in the buflist even though we did a `set nobuflisted`

`:bufadd` will create a new buffer for us so let's just use this

Closes #7