### PR TITLE
Use lua to parse basename of git repo path instead of bash command

### DIFF
--- a/lua/gitpad/init.lua
+++ b/lua/gitpad/init.lua
@@ -52,7 +52,8 @@ function M.init_gitpad_file(opts)
   end
 
   -- create the repository directory if it doesn't exist
-  local repository_name = vim.fn.systemlist("bash -c 'basename `git rev-parse --show-toplevel`'")[1]
+  local repository_path = vim.fn.systemlist('git rev-parse --show-toplevel')[1]
+  local repository_name = vim.fs.basename(repository_path)
   local notes_dir = vim.fs.normalize(M.config.dir .. '/' .. repository_name)
 
   -- create the notes directory if it doesn't exist


### PR DESCRIPTION
fix: repo name basename uses bash command which is slow on windows
- also will not work on some windows systems who do not have something like wsl setup
- instead grab git full path and use lua to parse the basename